### PR TITLE
Dockerfile with tools: jq, zip & awscli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM maven:3.3-jdk-8-alpine
+
+RUN apk add --no-cache jq zip
+
+RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "/tmp/get-pip.py" && \
+  python /tmp/get-pip.py && \
+  pip install awscli --ignore-installed six


### PR DESCRIPTION
Adds necessary tools for our builds to the base image maven:3.3-jdk-8-alpine
